### PR TITLE
✨feat: 투자 성향 진단 API 머지 요청

### DIFF
--- a/src/main/java/org/finmate/assessment/controller/AssessmentController.java
+++ b/src/main/java/org/finmate/assessment/controller/AssessmentController.java
@@ -1,0 +1,28 @@
+package org.finmate.assessment.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.finmate.assessment.dto.AssessmentDTO;
+import org.finmate.assessment.service.AssessmentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/assessment")
+public class AssessmentController {
+
+
+    private final AssessmentService assessmentService;
+
+    @GetMapping("")
+    public ResponseEntity<List<AssessmentDTO>> getList(){
+
+        return ResponseEntity.ok(assessmentService.loadAssessment());
+    }
+}

--- a/src/main/java/org/finmate/assessment/domain/AssessmentDetailsVO.java
+++ b/src/main/java/org/finmate/assessment/domain/AssessmentDetailsVO.java
@@ -1,0 +1,19 @@
+package org.finmate.assessment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AssessmentDetailsVO {
+
+    private final Long id;
+
+    private final String content;
+
+    private final int score;
+
+    private final String tag;
+
+}

--- a/src/main/java/org/finmate/assessment/domain/AssessmentVO.java
+++ b/src/main/java/org/finmate/assessment/domain/AssessmentVO.java
@@ -1,0 +1,17 @@
+package org.finmate.assessment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class AssessmentVO {
+
+    private final Long id;
+
+    private final List<AssessmentDetailsVO> choices;
+
+    private final String question;
+}

--- a/src/main/java/org/finmate/assessment/dto/AssessmentDTO.java
+++ b/src/main/java/org/finmate/assessment/dto/AssessmentDTO.java
@@ -1,0 +1,14 @@
+package org.finmate.assessment.dto;
+
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AssessmentDTO {
+
+    private Long id;
+    private String question;
+    private List<AssessmentDetailsDTO> choices;
+}

--- a/src/main/java/org/finmate/assessment/dto/AssessmentDetailsDTO.java
+++ b/src/main/java/org/finmate/assessment/dto/AssessmentDetailsDTO.java
@@ -1,0 +1,12 @@
+package org.finmate.assessment.dto;
+
+import lombok.Data;
+
+@Data
+public class AssessmentDetailsDTO {
+
+    private Long id;
+    private String content;
+    private int score;
+    private String tag;
+}

--- a/src/main/java/org/finmate/assessment/mapper/AssessmentMapper.java
+++ b/src/main/java/org/finmate/assessment/mapper/AssessmentMapper.java
@@ -1,0 +1,16 @@
+package org.finmate.assessment.mapper;
+
+
+import org.finmate.assessment.dto.AssessmentDTO;
+import org.finmate.assessment.dto.AssessmentDetailsDTO;
+
+import java.util.List;
+
+public interface AssessmentMapper {
+
+    public List<AssessmentDTO> getList();
+
+    public AssessmentDetailsDTO getDetailsById(Long id);
+
+    //int insertUserInfo(UserInfo userInfo);
+}

--- a/src/main/java/org/finmate/assessment/service/AssessmentService.java
+++ b/src/main/java/org/finmate/assessment/service/AssessmentService.java
@@ -1,0 +1,15 @@
+package org.finmate.assessment.service;
+
+
+import org.finmate.assessment.dto.AssessmentDTO;
+
+import java.util.List;
+
+public interface AssessmentService {
+
+    // GET
+    List<AssessmentDTO> loadAssessment();
+
+    // POST
+    void resultAssessment(Long userId, List<Integer> choice);
+}

--- a/src/main/java/org/finmate/assessment/service/AssessmentServiceImpl.java
+++ b/src/main/java/org/finmate/assessment/service/AssessmentServiceImpl.java
@@ -1,0 +1,26 @@
+package org.finmate.assessment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.finmate.assessment.dto.AssessmentDTO;
+import org.finmate.assessment.mapper.AssessmentMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssessmentServiceImpl implements AssessmentService{
+
+    private final AssessmentMapper assessmentMapper;
+
+    @Override
+    public List<AssessmentDTO> loadAssessment() {
+        return assessmentMapper.getList();
+    }
+
+    @Override
+    public void resultAssessment(Long userId, List<Integer> choice) {
+
+        // 유저 저장
+    }
+}

--- a/src/main/java/org/finmate/config/RootConfig.java
+++ b/src/main/java/org/finmate/config/RootConfig.java
@@ -4,10 +4,12 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
@@ -16,7 +18,14 @@ import javax.sql.DataSource;
 
 @Configuration
 @PropertySource({"classpath:/application.properties"})
-//@MapperScan(basePackages = {})
+@MapperScan(basePackages = {
+        "org.finmate.assessment.mapper",
+        "org.finmate.products.favorite.mapper",
+})
+@ComponentScan(basePackages={
+        "org.finmate.assessment.service",
+        "org.finmate.products.favorite.service",
+})
 public class RootConfig {
     @Value("${jdbc.driver}")
     String driver;

--- a/src/main/java/org/finmate/config/ServletConfig.java
+++ b/src/main/java/org/finmate/config/ServletConfig.java
@@ -15,7 +15,9 @@ import org.springframework.web.servlet.view.JstlView;
 @EnableWebMvc
 @ComponentScan(basePackages = {
         "org.finmate.exception",
-        "org.finmate.controller"
+        "org.finmate.controller",
+        "org.finmate.assessment.controller",
+        "org.finmate.products.favorite.controller",
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/resources/org/finmate/assessment/mapper/AssessmentMapper.xml
+++ b/src/main/resources/org/finmate/assessment/mapper/AssessmentMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.finmate.assessment.mapper.AssessmentMapper">
+
+    <!-- 1) resultMap -->
+    <resultMap id="AssessmentMap" type="org.finmate.assessment.dto.AssessmentDTO">
+        <!-- 부모 -->
+        <id     property="id"       column="a_id"/>
+        <result property="question" column="question"/>
+
+        <!-- 자식 목록 -->
+        <collection property="choices"
+                    ofType="org.finmate.assessment.dto.AssessmentDetailsDTO">
+            <id     property="id"      column="d_id"/>
+            <result property="content" column="content"/>
+            <result property="score"   column="score"/>
+            <result property="tag"     column="tag"/>
+        </collection>
+    </resultMap>
+
+    <!-- 2) select -->
+    <select id="getList" resultMap="AssessmentMap">
+        SELECT
+            a.id        AS a_id,
+            a.question  AS question,
+            d.id        AS d_id,
+            d.content   AS content,
+            d.score     AS score,
+            d.tag       AS tag
+        FROM assessment a
+                 JOIN assessment_details d
+                      ON d.assessment_id = a.id
+        ORDER BY a.id, d.id
+    </select>
+
+
+    <select id="getDetailsById" resultType="org.finmate.assessment.dto.AssessmentDetailsDTO">
+        SELECT id, content, score, tag
+        FROM assessment_details
+        WHERE id = #{id}
+    </select>
+
+
+</mapper>


### PR DESCRIPTION
- AssessmentController, Service, Mapper, VO/DTO 및 XML 매퍼 추가
- MyBatis resultMap 및 SQL alias 수정
- JSON 필드명(choices)로 변경
- RootConfig/ServletConfig에 스캐닝 설정 반영
- assessment 테이블에 details_id 삭제
- assessment_details 테이블에 assessment_id 추가
- issue: #2

## 🔗 반영 브랜치
(#2) feature/assessment -> develop

## 📝 작업 내용
<img width="1006" height="431" alt="image" src="https://github.com/user-attachments/assets/43e1b348-832d-46bd-b632-83c63ab45a80" />

## 💬 리뷰 요구사항(선택 사항)
1. 평가 DB의 칼럼이 변경 되었습니다. (기존 FK가 assessment에 있던걸 assessment_details로 옮김) _database.sql문을 새로 복붙하여 실행 바랍니다._
3. 노션 '데이터베이스 설계' 페이지에 _설문 리스트를 DB에 저장할 수 있도록 insert문을 올려놓았습니다._
: https://www.notion.so/231a447d7ddb80ed91b4c60d8fe464c2?source=copy_link
