### PR TITLE
♻️MyBatis Optional 처리 관련 로직 수정

### DIFF
--- a/src/main/java/org/finmate/product/mapper/ProductMapper.java
+++ b/src/main/java/org/finmate/product/mapper/ProductMapper.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface ProductMapper {
     List<ProductVO> getAllProducts();
 
-    Optional<ProductVO> getProductDetail(Long id);
+    ProductVO getProductDetail(Long id);
 
     List<ProductReviewVO> getProductReviewByProductId(Long productId);
 

--- a/src/main/java/org/finmate/product/service/ProductServiceImpl.java
+++ b/src/main/java/org/finmate/product/service/ProductServiceImpl.java
@@ -6,6 +6,7 @@ import org.finmate.common.util.OpenAiApi;
 import org.finmate.common.util.OpenAiDTO.OpenAiResponseDTO;
 import org.finmate.exception.NotFoundException;
 import org.finmate.product.domain.ProductReviewVO;
+import org.finmate.product.domain.ProductVO;
 import org.finmate.product.dto.ProductComparisonResultDTO;
 import org.finmate.product.dto.ProductDTO;
 import org.finmate.product.dto.ProductReviewDTO;
@@ -13,6 +14,7 @@ import org.finmate.product.mapper.ProductMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Log4j2
@@ -35,8 +37,9 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public ProductDTO<?> getProductDetail(Long id) {
-        return ProductDTO.from(productMapper.getProductDetail(id)
-                .orElseThrow(RuntimeException::new)
+        return ProductDTO.from(
+                Optional.ofNullable(productMapper.getProductDetail(id))
+                        .orElseThrow(() -> new NotFoundException("해당 상품이 존재하지 않습니다."))
         );
     }
 

--- a/src/main/java/org/finmate/quiz/mapper/QuizMapper.java
+++ b/src/main/java/org/finmate/quiz/mapper/QuizMapper.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 
 public interface QuizMapper {
     public QuizVO selectRandomQuiz();
-    public Optional<QuizVO> selectQuiz(Long quizId);
+    public QuizVO selectQuiz(Long quizId);
 }
 

--- a/src/main/java/org/finmate/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/org/finmate/quiz/service/QuizServiceImpl.java
@@ -8,6 +8,8 @@ import org.finmate.quiz.dto.QuizDTO;
 import org.finmate.quiz.mapper.QuizMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -20,7 +22,7 @@ public class QuizServiceImpl implements QuizService {
     }
 
     public String checkAnswer(QuizCheckRequestDTO dto) {
-        QuizVO quiz = quizMapper.selectQuiz(dto.getQuizId())
+        QuizVO quiz = Optional.ofNullable(quizMapper.selectQuiz(dto.getQuizId()))
                 .orElseThrow(() -> new RuntimeException("해당 퀴즈가 존재하지 않습니다."));
 
         if(quiz.isQuizAnswer() == dto.isAnswer()){


### PR DESCRIPTION
## 🔗 반영 브랜치
> (#34 ) feature/develop -> develop

## 📝 작업 내용
### MyBatis에서 Optional 반환 시 ClassCastException 에러 발생
### -> Service 로직에서 Optional 처리하도록 수정

**1. ProductMapper.java**
- Optional<ProductVO> getProductDetail(Long id) → ProductVO getProductDetail(Long id)로 변경
- Service (ProductServiceImpl.java) 에서 Optional.ofNullable(...)로 예외 처리 추가

**2. QuizMapper.java**
- Optional<QuizVO> selectQuiz(Long quizId) → QuizVO selectQuiz(Long quizId) 로 변경
- Service (QuizServiceImpl.java) 에서 Optional.ofNullable(...)로 예외 처리 추가

## 💬 리뷰 요구사항(선택 사항)

