### PR TITLE
♻️ 투자 성향 진단 테스트 API 사용자 ID 요청 방식 변경

### DIFF
--- a/src/main/java/org/finmate/assessment/controller/AssessmentController.java
+++ b/src/main/java/org/finmate/assessment/controller/AssessmentController.java
@@ -10,8 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.finmate.assessment.dto.AssessmentDTO;
 import org.finmate.assessment.dto.AssessmentRequestDTO;
 import org.finmate.assessment.service.AssessmentService;
+import org.finmate.member.domain.CustomUser;
 import org.finmate.member.dto.UserInfoDTO;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,8 +51,11 @@ public class AssessmentController {
      * 투자 성향 테스트 결과 user_info 반환 및 저장
      */
     @PostMapping("")
-    public ResponseEntity<UserInfoDTO> resultAssessment(@RequestBody AssessmentRequestDTO requestDTO){
-        Long userId = requestDTO.getUserId();
+    public ResponseEntity<UserInfoDTO> resultAssessment(
+            @AuthenticationPrincipal CustomUser customUser,
+            @RequestBody AssessmentRequestDTO requestDTO
+    ){
+        Long userId = customUser.getUser().getId();
         List<Integer> choices = requestDTO.getChoices();
 
         return ResponseEntity.of(assessmentService.resultAssessment(userId, choices));

--- a/src/main/java/org/finmate/assessment/dto/AssessmentRequestDTO.java
+++ b/src/main/java/org/finmate/assessment/dto/AssessmentRequestDTO.java
@@ -12,13 +12,6 @@ import java.util.List;
 @ApiModel(description = "사용자로부터 테스트 선택지를 받기 위한 DTO")
 public class AssessmentRequestDTO {
 
-    /**
-     * userId는 추후 토큰 형식으로 리팩토링 예정
-    **/
-
-    @ApiModelProperty(value = "사용자 ID", example = "1")
-    private Long userId; // 사용자 ID
-
     @ApiModelProperty(value = "사용자가 선택한 선택지에 따른 점수 리스트")
     private List<Integer> choices; // 사용자가 선택한 선택지들
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
> (#2 ) feature/assessment -> develop

## 📝 작업 내용
<img width="691" height="316" alt="image" src="https://github.com/user-attachments/assets/3350da9a-1363-4c6d-abd3-fa50219bb661" />

- AssessmentController.java CustomUser 을 활용하여 프론트에서 직접 사용자 아이디를 받지 않고 토큰 방식을 통해 직접 사용자 ID를 가져오도록 수정.

<br>

## 💬 리뷰 요구사항(선택 사항)
X
