### PR TITLE
♻️ 캐릭터 API 사용자 ID 요청 방식 변경

### DIFF
--- a/src/main/java/org/finmate/member/controller/AnimalCharacterController.java
+++ b/src/main/java/org/finmate/member/controller/AnimalCharacterController.java
@@ -7,10 +7,12 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.finmate.assessment.dto.AssessmentDTO;
+import org.finmate.member.domain.CustomUser;
 import org.finmate.member.dto.AnimalChangeDTO;
 import org.finmate.member.dto.AnimalCharacterDTO;
 import org.finmate.member.service.AnimalCharacterServiceImpl;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Log4j2
@@ -36,8 +38,8 @@ public class AnimalCharacterController {
                     response = AnimalCharacterDTO.class, responseContainer = "AnimalCharacterDTO"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
-    public ResponseEntity<AnimalCharacterDTO> getCharacter(@PathVariable Long userId){
-        return ResponseEntity.of(characterService.getCharacterById(userId));
+    public ResponseEntity<AnimalCharacterDTO> getCharacter(@AuthenticationPrincipal CustomUser customUser){
+        return ResponseEntity.of(characterService.getCharacterById(customUser.getUser().getId()));
     }
 
     /**
@@ -53,8 +55,11 @@ public class AnimalCharacterController {
                     response = AnimalCharacterDTO.class, responseContainer = "AnimalCharacterDTO"),
             @ApiResponse(code = 500, message = "서버 오류")
     })
-    public ResponseEntity<AnimalCharacterDTO> changeCharacter(@RequestBody AnimalChangeDTO animalChangeDTO){
-        Long userId = animalChangeDTO.getUserId();
+    public ResponseEntity<AnimalCharacterDTO> changeCharacter(
+            @AuthenticationPrincipal CustomUser customUser,
+            @RequestBody AnimalChangeDTO animalChangeDTO)
+    {
+        Long userId = customUser.getUser().getId();
         Long animalId = animalChangeDTO.getAnimalId();
 
         return ResponseEntity.of(characterService.changeCharacterById(userId, animalId));

--- a/src/main/java/org/finmate/member/dto/AnimalChangeDTO.java
+++ b/src/main/java/org/finmate/member/dto/AnimalChangeDTO.java
@@ -10,8 +10,6 @@ import lombok.NoArgsConstructor;
 @ApiModel(description = "캐릭터 POST 전용 DTO")
 public class AnimalChangeDTO {
 
-    @ApiModelProperty(value = "사용자 ID", example = "3")
-    private Long userId;
     @ApiModelProperty(value = "동물 캐릭터 ID", example = "2")
     private Long animalId;
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
>  (#24 ) feature/character -> develop

## 📝 작업 내용
<img width="867" height="582" alt="image" src="https://github.com/user-attachments/assets/11791e56-f171-4369-b080-22def0b53bc7" />
- CharacterController.java CustomUser 을 활용하여 프론트에서 직접 사용자 아이디를 받지 않고 토큰 방식을 통해 직접 사용자 ID를 가져오도록 수정.

<br>

## 💬 리뷰 요구사항(선택 사항)
X