### PR TITLE
✨ 카카오 로그인 API 연동 및 프론트 리다이렉트 처리

### DIFF
--- a/src/main/java/org/finmate/member/controller/KakaoAuthController.java
+++ b/src/main/java/org/finmate/member/controller/KakaoAuthController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.Map;
 
 @Log4j2
@@ -33,10 +35,11 @@ public class KakaoAuthController {
     // 인가코드 받아서 로그인 처리
     @ApiOperation(value = "카카오 로그인 콜백", notes = "인가 코드를 받아 카카오 로그인 처리 및 JWT 발급")
     @GetMapping("/callback")
-    public ResponseEntity<?> kakaoCallback(
+    public void kakaoCallback(
             @ApiParam(value = "카카오 인가 코드", required = true)
-            @RequestParam String code
-    ) {
+            @RequestParam String code,
+            HttpServletResponse response
+    ) throws IOException {
         // 1. 인가코드로 액세스 토큰 요청
         String accessToken = kakaoService.getAccessToken(code);
 
@@ -51,10 +54,12 @@ public class KakaoAuthController {
         // 4. JWT 발급
         String jwt = jwtProcessor.generateToken(user.getAccountId());
 
-        // 5. JWT 반환
-        UserInfoDTO userInfoDTO = UserInfoDTO.of(user);
-        AuthResultDTO authResultDTO = new AuthResultDTO(jwt, userInfoDTO);
-
-        return ResponseEntity.ok(authResultDTO);
+        // 5. 프론트로 redirect (토큰 쿼리로 전달)
+        String redirectUrl = "http://localhost:5173/auth/kakao/redirect?token="+jwt;
+        response.sendRedirect(redirectUrl);
+//        UserInfoDTO userInfoDTO = UserInfoDTO.of(user);
+//        AuthResultDTO authResultDTO = new AuthResultDTO(jwt, userInfoDTO);
+//
+//        return ResponseEntity.ok(authResultDTO);
     }
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
(#38 ) feature/oauth-kakao-login -> develop

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- JWT 생성 후 프론트엔드로 리다이렉트하며 전달
- 프론트 테스트용 redirect URI 적용 (localhost:5173)
- 프론트에서 로그인 버튼 클릭 시 정상적으로 카카오 인증 페이지로 이동
-  JWT 발급 후 `http://localhost:5173/auth/kakao/redirect`로 리다이렉트 확인


## 💬 리뷰 요구사항(선택 사항)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
