### PR TITLE
♻️ 재무 포트폴리오 userId 요청 방식 변경

### DIFF
--- a/src/main/java/org/finmate/portfolio/controller/PortfolioController.java
+++ b/src/main/java/org/finmate/portfolio/controller/PortfolioController.java
@@ -6,10 +6,12 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import lombok.extern.slf4j.Slf4j;
+import org.finmate.member.domain.CustomUser;
 import org.finmate.portfolio.dto.PortfolioApiResponse;
 import org.finmate.portfolio.dto.PortfolioDTO;
 import org.finmate.portfolio.service.PortfolioService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -24,7 +26,11 @@ public class PortfolioController {
 
     @ApiOperation(value = "재무 포트폴리오 등록", notes = "사용자의 재무 포트폴리오를 등록")
     @PostMapping
-    public ResponseEntity<PortfolioApiResponse<Long>> create(@RequestBody PortfolioDTO dto) {
+    public ResponseEntity<PortfolioApiResponse<Long>> create(
+            @AuthenticationPrincipal CustomUser customUser,
+            @RequestBody PortfolioDTO dto) {
+        Long userId = customUser.getUser().getId();
+        dto.setUserId(userId);
         portfolioService.createPortfolio(dto);
         return ResponseEntity.ok(PortfolioApiResponse.<Long>builder()
                 .message("재무 포트폴리오 등록 완료")
@@ -34,14 +40,20 @@ public class PortfolioController {
 
     @ApiOperation(value = "재무 포트폴리오 조회", notes = "userId로 재무 포트폴리오를 조회")
     @GetMapping
-    public ResponseEntity<PortfolioDTO> get(@RequestParam Long userId) {
+    public ResponseEntity<PortfolioDTO> get(@AuthenticationPrincipal CustomUser customUser) {
+        Long userId = customUser.getUser().getId();
         PortfolioDTO dto = portfolioService.getPortfolioByUserId(userId);
         return ResponseEntity.ok(dto);
     }
 
     @ApiOperation(value = "재무 포트폴리오 수정", notes = "재무 포트폴리오 수정")
     @PatchMapping
-    public ResponseEntity<PortfolioApiResponse<Long>> update(@RequestBody PortfolioDTO dto) {
+    public ResponseEntity<PortfolioApiResponse<Long>> update(
+            @AuthenticationPrincipal CustomUser customUser,
+            @RequestBody PortfolioDTO dto)
+    {
+        Long userId = customUser.getUser().getId();
+        dto.setUserId(userId);
         portfolioService.updatePortfolio(dto);
         return ResponseEntity.ok(
                 PortfolioApiResponse.<Long>builder()
@@ -53,7 +65,8 @@ public class PortfolioController {
 
     @ApiOperation(value = "재무 포트폴리오 삭제", notes = "userId로 재무 포트폴리오를 삭제")
     @DeleteMapping
-    public ResponseEntity<PortfolioApiResponse<Long>> delete(@RequestParam Long userId) {
+    public ResponseEntity<PortfolioApiResponse<Long>> delete(@AuthenticationPrincipal CustomUser customUser) {
+        Long userId = customUser.getUser().getId();
         portfolioService.deletePortfolioByUserId(userId);
         return ResponseEntity.ok(
                 PortfolioApiResponse.<Long>builder()


### PR DESCRIPTION
## 🔗 반영 브랜치
(#55) feature/portfolio -> develop

## 📝 작업 내용
1. 기존 userId를 파라미터 통해 직접 받는 방식에서 @AuthenticationPrincipal CustomUser customUser을 통해 주입하는 형태로 변경
<img width="896" height="485" alt="image" src="https://github.com/user-attachments/assets/f481ed7f-45e7-4ed9-ab81-5c8b71fd5b90" />



## 💬 리뷰 요구사항(선택 사항)

