### PR TITLE
✨ 랜덤 금융상품 추천 조회 API 머지 요청

### DIFF
--- a/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
+++ b/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
@@ -1,6 +1,9 @@
 package org.finmate.product.controller;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.finmate.product.dto.ProductDTO;
@@ -23,6 +26,11 @@ public class ProductRecommendationController {
 
     private final ProductMapper productMapper;
 
+    @ApiOperation(value = "랜덤 상품 추천", notes = "메인 화면에서 무작위로 금융 상품 8개를 추천합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "정상적으로 랜덤 추천 상품을 반환했습니다."),
+            @ApiResponse(code = 500, message = "서버 오류 발생")
+    })
     @GetMapping("/random")
     ResponseEntity<List<ProductDTO<?>>> getRandomProductRecommendation(){
         return ResponseEntity.ok(productMapper.getRandomProductRecommendation()

--- a/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
+++ b/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
@@ -1,0 +1,33 @@
+package org.finmate.product.controller;
+
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.finmate.product.dto.ProductDTO;
+import org.finmate.product.mapper.ProductMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/product/recommendation")
+@Api(tags = "상품 추천 API")
+public class ProductRecommendationController {
+
+
+    private final ProductMapper productMapper;
+
+    @GetMapping("/random")
+    ResponseEntity<List<ProductDTO<?>>> getRandomProductRecommendation(){
+        return ResponseEntity.ok(productMapper.getRandomProductRecommendation()
+                .stream()
+                .map(ProductDTO::from)
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/org/finmate/product/mapper/ProductMapper.java
+++ b/src/main/java/org/finmate/product/mapper/ProductMapper.java
@@ -35,5 +35,8 @@ public interface ProductMapper {
             @Param("productId") Long productId,
             @Param("userId") Long userId);
 
+    // 상품 추천 (랜덤)
+    List<ProductVO> getRandomProductRecommendation();
+
 }
 

--- a/src/main/resources/org/finmate/product/mapper/ProductMapper.xml
+++ b/src/main/resources/org/finmate/product/mapper/ProductMapper.xml
@@ -299,4 +299,13 @@
         WHERE user_id = #{userId}
         AND product_id = #{productId}
     </delete>
+
+    <!-- ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ 상품 추천 관련 SQL ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ -->
+    <!-- 상품 추천 (랜덤) -->
+    <select id="getRandomProductRecommendation" resultMap="ProductWithType">
+        SELECT <include refid="productSelectColumns"/>
+            <include refid="productJoin"/>
+        ORDER BY RAND()
+        LIMIT 8
+    </select>
 </mapper>


### PR DESCRIPTION
## 🔗 반영 브랜치  
(#63 ) feature/recommendation → develop

---

## 📝 작업 내용
- **랜덤 금융상품 추천 API 구현**
  -  `/api/product/recommendation/random` 엔드포인트 추가
  - 금융상품 테이블(`financial_product`)과 상세 테이블(`product_deposit`, `product_savings`, `product_fund`, `product_rate`)을 LEFT JOIN하여 무작위 상품 8개 조회
<img width="892" height="836" alt="image" src="https://github.com/user-attachments/assets/e7ebfced-3154-46d5-85a5-17ee3252c9ab" />

---

## 📎 기타 참고 사항
- 이후 `/api/product/recommendation/all`에 사용자 성향 기반 추천 알고리즘 추가 예정
