### PR TITLE
✨ 카카오 로그인 사용자 정보 추가

### DIFF
--- a/src/main/java/org/finmate/member/domain/KakaoUser.java
+++ b/src/main/java/org/finmate/member/domain/KakaoUser.java
@@ -9,4 +9,6 @@ public class KakaoUser {
     private String id;
     private String nickname;
     private String email;
+    private String gender;
+    private String birth;
 }

--- a/src/main/java/org/finmate/member/dto/KakaoUserResponse.java
+++ b/src/main/java/org/finmate/member/dto/KakaoUserResponse.java
@@ -20,5 +20,13 @@ public class KakaoUserResponse {
     @Data
     public static class KakaoAccount {
         private String email;
+        private String gender;
+        private String birthyear;
+        private String birthday;
+        // has_xx : 해당 값이 존재하고 사용자 동의했는지 여부 알려줌 (필수 동의라서 필요없지만, 선택항목으로 바뀔수도 있으니까..)
+        private Boolean has_email;
+        private Boolean has_gender;
+        private Boolean has_birthyear;
+        private Boolean has_birthday;
     }
 }

--- a/src/main/java/org/finmate/member/service/KakaoService.java
+++ b/src/main/java/org/finmate/member/service/KakaoService.java
@@ -8,7 +8,11 @@ import org.finmate.member.domain.UserVO;
 import org.finmate.member.domain.enums.Provider;
 import org.finmate.member.dto.KakaoTokenResponse;
 import org.finmate.member.dto.KakaoUserResponse;
+import org.finmate.member.dto.UserInfoDTO;
 import org.finmate.member.mapper.UserMapper;
+import org.finmate.security.dto.AuthResultDTO;
+import org.finmate.security.dto.UserLoginInfoDTO;
+import org.finmate.security.util.JwtProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -22,6 +26,7 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class KakaoService {
 
+    private final JwtProcessor jwtProcessor;
     @Value("${kakao.client-id}")
     private String CLIENT_ID;
 
@@ -94,28 +99,52 @@ public class KakaoService {
         }
     }
 
-    // 3. 우리 서비스의 사용자로 DB에 저장 or 조회
-    public UserVO getOrCreateUser(KakaoUser kakaoUser){
-        String accountId = "kakao_" + kakaoUser.getId();
 
-        UserVO existingUser = userMapper.selectByAccountId(accountId);
-        if(existingUser != null){
-            System.out.println("기존 사용자: " + existingUser);
-            return existingUser;
+    public AuthResultDTO getOrCreateUserAndBuildAuthDTO(KakaoUser kakaoUser){
+        String accountId = "kakao_" + kakaoUser.getId();
+        UserVO user = userMapper.selectByAccountId(accountId);
+
+        boolean isNewUser = false;
+        if(user == null){
+            user = UserVO.builder()
+                    .accountId(accountId)
+                    .email(kakaoUser.getEmail())
+                    .name(kakaoUser.getNickname())
+                    .password("kakao")
+                    .provider(Provider.KAKAO)
+                    .build();
+            userMapper.insertUser(user);
+            isNewUser = true;
         }
 
-        UserVO newUser = UserVO.builder()
-                .accountId(accountId)
-                .email(kakaoUser.getEmail())
-                .name(kakaoUser.getNickname())
-                .password("kakao")
-                .provider(Provider.KAKAO)
-                .build();
+        String token = jwtProcessor.generateToken(user.getAccountId());
+        UserLoginInfoDTO userLoginInfoDTO = UserLoginInfoDTO.of(user);
 
-        log.info("새 사용자 생성: {}", newUser);
-
-        userMapper.insertUser(newUser);
-        return newUser;
+        return new AuthResultDTO(token, userLoginInfoDTO, isNewUser);
     }
+
+
+//    // 3. 우리 서비스의 사용자로 DB에 저장 or 조회
+//    public UserVO getOrCreateUser(KakaoUser kakaoUser){
+//        String accountId = "kakao_" + kakaoUser.getId();
+//
+//        UserVO existingUser = userMapper.selectByAccountId(accountId);
+//        if(existingUser != null){
+//            return existingUser;
+//        }
+//
+//        UserVO newUser = UserVO.builder()
+//                .accountId(accountId)
+//                .email(kakaoUser.getEmail())
+//                .name(kakaoUser.getNickname())
+//                .password("kakao")
+//                .provider(Provider.KAKAO)
+//                .build();
+//
+//        log.info("새 사용자 생성: {}", newUser);
+//
+//        userMapper.insertUser(newUser);
+//        return newUser;
+//    }
 
 }

--- a/src/main/java/org/finmate/member/service/KakaoService.java
+++ b/src/main/java/org/finmate/member/service/KakaoService.java
@@ -113,7 +113,7 @@ public class KakaoService {
                     .password("kakao")
                     .provider(Provider.KAKAO)
                     .build();
-            userMapper.insertUser(user);
+//            userMapper.insertUser(user);
             isNewUser = true;
         }
 
@@ -122,29 +122,4 @@ public class KakaoService {
 
         return new AuthResultDTO(token, userLoginInfoDTO, isNewUser);
     }
-
-
-//    // 3. 우리 서비스의 사용자로 DB에 저장 or 조회
-//    public UserVO getOrCreateUser(KakaoUser kakaoUser){
-//        String accountId = "kakao_" + kakaoUser.getId();
-//
-//        UserVO existingUser = userMapper.selectByAccountId(accountId);
-//        if(existingUser != null){
-//            return existingUser;
-//        }
-//
-//        UserVO newUser = UserVO.builder()
-//                .accountId(accountId)
-//                .email(kakaoUser.getEmail())
-//                .name(kakaoUser.getNickname())
-//                .password("kakao")
-//                .provider(Provider.KAKAO)
-//                .build();
-//
-//        log.info("새 사용자 생성: {}", newUser);
-//
-//        userMapper.insertUser(newUser);
-//        return newUser;
-//    }
-
 }

--- a/src/main/java/org/finmate/member/service/KakaoService.java
+++ b/src/main/java/org/finmate/member/service/KakaoService.java
@@ -87,11 +87,20 @@ public class KakaoService {
             String id = String.valueOf(kakaoResponse.getId());
             String nickname = kakaoResponse.getProperties().getNickname();
             String email = kakaoResponse.getKakao_account().getEmail();
-            log.info("getUserInfo - id: {}, nickname: {}, email: {}", id, nickname, email);
+            String gender = kakaoResponse.getKakao_account().getGender();
+            String birthyear = kakaoResponse.getKakao_account().getBirthyear();
+            String birthday = kakaoResponse.getKakao_account().getBirthday();
 
+            String birth = null;
+            if(birthyear != null && birthday != null){
+                birth = birthyear +"-"+birthday.substring(0,2) + "-"+birthday.substring(2);
+            }
+            log.info("getUserInfo - id: {}, nickname: {}, email: {}, gender: {}, birth: {}",
+                    id, nickname, email, gender, birth);
             return new KakaoUser(id,
                     nickname != null ? nickname : "카카오사용자",
-                    email != null ? email : "no-email@kakao.com");
+                    email != null ? email : "no-email@kakao.com",
+                    gender, birth);
         }
         catch (Exception e) {
             log.error("카카오 사용자 정보 파싱 실패: {}", e.getMessage());
@@ -113,7 +122,6 @@ public class KakaoService {
                     .password("kakao")
                     .provider(Provider.KAKAO)
                     .build();
-//            userMapper.insertUser(user);
             isNewUser = true;
         }
 

--- a/src/main/java/org/finmate/security/dto/AuthResultDTO.java
+++ b/src/main/java/org/finmate/security/dto/AuthResultDTO.java
@@ -9,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthResultDTO {
     private String token;
-    private UserInfoDTO user;
+    private UserLoginInfoDTO user;
+    private boolean isNewUser;
 }

--- a/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
+++ b/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
@@ -10,13 +10,13 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserInfoDTO {
+public class UserLoginInfoDTO {
     private String username;
     private String email;
     private List<String> roles;
 
-    public static UserInfoDTO of(UserVO member){
-        return new UserInfoDTO(
+    public static UserLoginInfoDTO of(UserVO member){
+        return new UserLoginInfoDTO(
                 member.getAccountId(),
                 member.getEmail(),
                 List.of("ROLE_USER") // 현재는 고정값으로 설정

--- a/src/main/java/org/finmate/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/org/finmate/security/handler/LoginSuccessHandler.java
@@ -5,7 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.finmate.member.domain.CustomUser;
 import org.finmate.member.domain.UserVO;
 import org.finmate.security.dto.AuthResultDTO;
-import org.finmate.security.dto.UserInfoDTO;
+import org.finmate.security.dto.UserLoginInfoDTO;
 import org.finmate.security.util.JsonResponse;
 import org.finmate.security.util.JwtProcessor;
 import org.springframework.security.core.Authentication;
@@ -30,8 +30,8 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         UserVO userVO = customUser.getUser();
 
         String token = jwtProcessor.generateToken(userVO.getAccountId());
-        UserInfoDTO userInfo = UserInfoDTO.of(userVO);
-        AuthResultDTO result = new AuthResultDTO(token, userInfo);
+        UserLoginInfoDTO userInfo = UserLoginInfoDTO.of(userVO);
+        AuthResultDTO result = new AuthResultDTO(token, userInfo, false);
 
         JsonResponse.send(response,result);
     }


### PR DESCRIPTION
## 🔗 반영 브랜치
(#65) feature/kakao-login -> develop

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 카카오 인가코드 받아오기
- 백엔드에서 access_token 발급 및 사용자 정보 조회
(이름, 이메일, 성별, 출생년도, 생일)
- 사용자 정보 받아와서 KakaoUser 객체로 파싱
- 신규 사용자인 경우, 회원 db에 저장되지 않음 (isNewUser 플래그 사용)

## 💬 리뷰 요구사항(선택 사항)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
