### PR TITLE
✨ 카카오 로그인 신규 회원 정보 + 설문 응답 통합 처리

### DIFF
--- a/src/main/java/org/finmate/member/dto/SignupRequestDTO.java
+++ b/src/main/java/org/finmate/member/dto/SignupRequestDTO.java
@@ -12,6 +12,9 @@ import lombok.*;
 @ApiModel(value = "회원가입 요청", description = "회원가입 시 필요한 사용자 정보 DTO")
 public class SignupRequestDTO {
 
+    @ApiModelProperty(value = "가입 방식", example = "LOCAL 또는 KAKAO")
+    private String provider;
+
     @ApiModelProperty(value = "사용자 이름", example = "홍길동")
     private String name;
 

--- a/src/main/java/org/finmate/member/service/KakaoService.java
+++ b/src/main/java/org/finmate/member/service/KakaoService.java
@@ -129,14 +129,14 @@ public class KakaoService {
 
         String token = jwtProcessor.generateToken(user.getAccountId());
 
-        UserLoginInfoDTO userLoginInfoDTO = new UserLoginInfoDTO(
-                accountId,
-                kakaoUser.getEmail(),
-                kakaoUser.getNickname(),
-                kakaoUser.getBirth(),
-                kakaoUser.getGender(),
-                List.of("ROLE_USER")
-        );
+        UserLoginInfoDTO userLoginInfoDTO = UserLoginInfoDTO.builder()
+                .accountId(accountId)
+                .email(kakaoUser.getEmail())
+                .name(kakaoUser.getNickname())
+                .birth(kakaoUser.getBirth())
+                .gender(kakaoUser.getGender())
+                .roles(List.of("ROLE_USER"))
+                .build();
 
         return new AuthResultDTO(token, userLoginInfoDTO, isNewUser);
     }

--- a/src/main/java/org/finmate/member/service/KakaoService.java
+++ b/src/main/java/org/finmate/member/service/KakaoService.java
@@ -20,6 +20,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
 
 @Log4j2
 @Service
@@ -126,7 +128,15 @@ public class KakaoService {
         }
 
         String token = jwtProcessor.generateToken(user.getAccountId());
-        UserLoginInfoDTO userLoginInfoDTO = UserLoginInfoDTO.of(user);
+
+        UserLoginInfoDTO userLoginInfoDTO = new UserLoginInfoDTO(
+                accountId,
+                kakaoUser.getEmail(),
+                kakaoUser.getNickname(),
+                kakaoUser.getBirth(),
+                kakaoUser.getGender(),
+                List.of("ROLE_USER")
+        );
 
         return new AuthResultDTO(token, userLoginInfoDTO, isNewUser);
     }

--- a/src/main/java/org/finmate/member/service/SignupService.java
+++ b/src/main/java/org/finmate/member/service/SignupService.java
@@ -1,6 +1,7 @@
 package org.finmate.member.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.finmate.member.domain.UserInfoVO;
 import org.finmate.member.domain.enums.*;
 import org.finmate.member.mapper.UserInfoMapper;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class SignupService {
@@ -25,42 +27,68 @@ public class SignupService {
 
     @Transactional
     public void signup(SignupRequestDTO dto) {
-        if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+
+        try {
+            String provider = dto.getProvider() != null ? dto.getProvider().toUpperCase() : "LOCAL";
+
+            // 비밀번호 체크( LOCAL일 때만)
+            if ("LOCAL".equals(provider)) {
+                if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
+                    throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+                }
+            }
+//        if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
+//            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+//        }
+            if (userMapper.existsByAccountId(dto.getAccountId())) {
+                throw new RuntimeException("이미 사용 중인 아이디입니다.");
+            }
+
+            String encodedPassword;
+            if ("KAKAO".equals(provider)) {
+                encodedPassword = "kakao"; // 그냥 더미로 넣는 비밀번호
+            } else {
+                encodedPassword = passwordEncoder.encode(dto.getPassword());
+            }
+            //String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
+            UserVO user = UserVO.builder()
+                    .name(dto.getName())
+                    .accountId(dto.getAccountId())
+                    .email(dto.getEmail())
+                    .password(encodedPassword)
+                    .provider(Provider.valueOf(provider))
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            userMapper.insertUser(user);
+
+            log.debug("User inserted: {}", user);  // ✅ 추가된 로그
+
+            UserInfoVO userInfo = UserInfoVO.builder()
+                    .userId(user.getId())
+                    .birth(LocalDate.parse(dto.getBirth()))
+                    .gender(Gender.valueOf(dto.getGender().toUpperCase()))
+                    .isMarried(dto.getIsMarried())
+                    .hasJob(dto.getHasJob())
+                    .usesPublicTransport(dto.getUsesPublicTransport())
+                    .doesExercise(dto.getDoesExercise())
+                    .travelsFrequently(dto.getTravelsFrequently())
+                    .hasChildren(dto.getHasChildren())
+                    .hasHouse(dto.getHasHouse())
+                    .employedAtSme(dto.getEmployedAtSme())
+                    .usesMicroloan(dto.getUsesMicroloan())
+                    .exp(0)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+            userInfoMapper.insertUserInfo(userInfo);
+            log.debug("UserInfo inserted: {}", userInfo);  // ✅ 추가된 로그
+
         }
-        if (userMapper.existsByAccountId(dto.getAccountId())) {
-            throw new RuntimeException("이미 사용 중인 아이디입니다.");
+        catch (Exception e)
+        {
+            log.error("❌111111 회원가입 중 예외 발생: {}", e.getMessage(), e);  // 예외 전체 로그 출력
+            throw e; // 예외 다시 던짐 (트랜잭션 롤백 등 유지)
         }
-
-        String encodedPassword = passwordEncoder.encode(dto.getPassword());
-
-        UserVO user = UserVO.builder()
-                .name(dto.getName())
-                .accountId(dto.getAccountId())
-                .email(dto.getEmail())
-                .password(encodedPassword)
-                .provider(Provider.LOCAL)
-                .createdAt(LocalDateTime.now())
-                .build();
-        userMapper.insertUser(user);
-
-        UserInfoVO userInfo = UserInfoVO.builder()
-                .userId(user.getId())
-                .birth(LocalDate.parse(dto.getBirth()))
-                .gender(Gender.valueOf(dto.getGender()))
-                .isMarried(dto.getIsMarried())
-                .hasJob(dto.getHasJob())
-                .usesPublicTransport(dto.getUsesPublicTransport())
-                .doesExercise(dto.getDoesExercise())
-                .travelsFrequently(dto.getTravelsFrequently())
-                .hasChildren(dto.getHasChildren())
-                .hasHouse(dto.getHasHouse())
-                .employedAtSme(dto.getEmployedAtSme())
-                .usesMicroloan(dto.getUsesMicroloan())
-                .exp(0)
-                .updatedAt(LocalDateTime.now())
-                .build();
-        userInfoMapper.insertUserInfo(userInfo);
     }
 
     public boolean isAccountIdDuplicate(String accountId) {

--- a/src/main/java/org/finmate/member/service/SignupService.java
+++ b/src/main/java/org/finmate/member/service/SignupService.java
@@ -65,7 +65,7 @@ public class SignupService {
                     .build();
             userMapper.insertUser(user);
 
-            log.debug("User inserted: {}", user);  // ✅ 추가된 로그
+            log.debug("User inserted: {}", user);
 
             UserInfoVO userInfo = UserInfoVO.builder()
                     .userId(user.getId())
@@ -84,13 +84,13 @@ public class SignupService {
                     .updatedAt(LocalDateTime.now())
                     .build();
             userInfoMapper.insertUserInfo(userInfo);
-            log.debug("UserInfo inserted: {}", userInfo);  // ✅ 추가된 로그
+            log.debug("UserInfo inserted: {}", userInfo);
 
         }
         catch (Exception e)
         {
-            log.error("111111 회원가입 중 예외 발생: {}", e.getMessage(), e);  // 예외 전체 로그 출력
-            throw e; // 예외 다시 던짐 (트랜잭션 롤백 등 유지)
+            log.error("111111 회원가입 중 예외 발생: {}", e.getMessage(), e);
+            throw e;
         }
 
 

--- a/src/main/java/org/finmate/member/service/SignupService.java
+++ b/src/main/java/org/finmate/member/service/SignupService.java
@@ -29,6 +29,9 @@ public class SignupService {
     public void signup(SignupRequestDTO dto) {
 
         try {
+            log.info("[SignupService] 전달받은 provider: {}", dto.getProvider());
+
+
             String provider = dto.getProvider() != null ? dto.getProvider().toUpperCase() : "LOCAL";
 
             // 비밀번호 체크( LOCAL일 때만)
@@ -86,9 +89,11 @@ public class SignupService {
         }
         catch (Exception e)
         {
-            log.error("❌111111 회원가입 중 예외 발생: {}", e.getMessage(), e);  // 예외 전체 로그 출력
+            log.error("111111 회원가입 중 예외 발생: {}", e.getMessage(), e);  // 예외 전체 로그 출력
             throw e; // 예외 다시 던짐 (트랜잭션 롤백 등 유지)
         }
+
+
     }
 
     public boolean isAccountIdDuplicate(String accountId) {

--- a/src/main/java/org/finmate/member/service/SignupService.java
+++ b/src/main/java/org/finmate/member/service/SignupService.java
@@ -31,36 +31,36 @@ public class SignupService {
         try {
             log.info("[SignupService] 전달받은 provider: {}", dto.getProvider());
 
+            Provider provider = dto.getProvider() != null ? Provider.valueOf(dto.getProvider().toUpperCase()) : Provider.LOCAL;
 
-            String provider = dto.getProvider() != null ? dto.getProvider().toUpperCase() : "LOCAL";
-
-            // 비밀번호 체크( LOCAL일 때만)
-            if ("LOCAL".equals(provider)) {
-                if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
-                    throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-                }
-            }
-//        if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
-//            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-//        }
             if (userMapper.existsByAccountId(dto.getAccountId())) {
                 throw new RuntimeException("이미 사용 중인 아이디입니다.");
             }
 
             String encodedPassword;
-            if ("KAKAO".equals(provider)) {
-                encodedPassword = "kakao"; // 그냥 더미로 넣는 비밀번호
-            } else {
-                encodedPassword = passwordEncoder.encode(dto.getPassword());
+            switch(provider){
+                case LOCAL:
+                    if(!dto.getPassword().equals(dto.getPasswordConfirm())){
+                        throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+                    }
+                    encodedPassword = passwordEncoder.encode(dto.getPassword());
+                    break;
+
+                case KAKAO:
+                    encodedPassword = "kakao"; //더미 비밀번호
+                    break;
+
+                default :
+                    throw new IllegalArgumentException("지원하지 않는 provider입니다: " + provider);
+
             }
-            //String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
             UserVO user = UserVO.builder()
                     .name(dto.getName())
                     .accountId(dto.getAccountId())
                     .email(dto.getEmail())
                     .password(encodedPassword)
-                    .provider(Provider.valueOf(provider))
+                    .provider(provider)
                     .createdAt(LocalDateTime.now())
                     .build();
             userMapper.insertUser(user);

--- a/src/main/java/org/finmate/member/service/SignupService.java
+++ b/src/main/java/org/finmate/member/service/SignupService.java
@@ -87,10 +87,9 @@ public class SignupService {
             log.debug("UserInfo inserted: {}", userInfo);
 
         }
-        catch (Exception e)
-        {
-            log.error("111111 회원가입 중 예외 발생: {}", e.getMessage(), e);
-            throw e;
+        catch (RuntimeException e) {
+            log.error("회원가입 처리 중 예외 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("회원가입 처리 중 오류가 발생했습니다. 다시 시도해주세요.");
         }
 
 

--- a/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
+++ b/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
@@ -11,15 +11,32 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserLoginInfoDTO {
-    private String username;
+    private String accountId;
     private String email;
+    private String name;
+    private String birth;
+    private String gender;
     private List<String> roles;
 
-    public static UserLoginInfoDTO of(UserVO member){
+    public static UserLoginInfoDTO of(UserVO user){
         return new UserLoginInfoDTO(
-                member.getAccountId(),
-                member.getEmail(),
-                List.of("ROLE_USER") // 현재는 고정값으로 설정
+                user.getAccountId(),
+                user.getEmail(),
+                user.getName(),
+                null, // birth (UserVO에 없으므로 null)
+                null, // gender (UserVO에 없으므로 null)
+                List.of("ROLE_USER")
         );
     }
+
+//    public static UserLoginInfoDTO of(UserVO user){
+//        return new UserLoginInfoDTO(
+//                user.getAccountId(),
+//                user.getEmail(),
+//                user.getName(),
+//                user.getBirth(),
+//                user.getGender(),
+//                List.of("ROLE_USER") // 현재는 고정값으로 설정
+//        );
+//    }
 }

--- a/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
+++ b/src/main/java/org/finmate/security/dto/UserLoginInfoDTO.java
@@ -1,8 +1,10 @@
 package org.finmate.security.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.finmate.member.domain.KakaoUser;
 import org.finmate.member.domain.UserVO;
 
 import java.util.List;
@@ -10,6 +12,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class UserLoginInfoDTO {
     private String accountId;
     private String email;
@@ -19,24 +22,24 @@ public class UserLoginInfoDTO {
     private List<String> roles;
 
     public static UserLoginInfoDTO of(UserVO user){
-        return new UserLoginInfoDTO(
-                user.getAccountId(),
-                user.getEmail(),
-                user.getName(),
-                null, // birth (UserVO에 없으므로 null)
-                null, // gender (UserVO에 없으므로 null)
-                List.of("ROLE_USER")
-        );
+        return UserLoginInfoDTO.builder()
+                .accountId(user.getAccountId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .birth(null)
+                .gender(null)
+                .roles(List.of("ROLE_USER"))
+                .build();
     }
 
-//    public static UserLoginInfoDTO of(UserVO user){
-//        return new UserLoginInfoDTO(
-//                user.getAccountId(),
-//                user.getEmail(),
-//                user.getName(),
-//                user.getBirth(),
-//                user.getGender(),
-//                List.of("ROLE_USER") // 현재는 고정값으로 설정
-//        );
-//    }
+    public static UserLoginInfoDTO of(KakaoUser kakaoUser){
+        return UserLoginInfoDTO.builder()
+                .accountId("kakao_" + kakaoUser.getId())
+                .email(kakaoUser.getEmail())
+                .name(kakaoUser.getNickname())
+                .birth(kakaoUser.getBirth())
+                .gender(kakaoUser.getGender())
+                .roles(List.of("ROLE_USER"))
+                .build();
+    }
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
(#65 ) feature/kakao-login -> develop

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 주요 변경 사항
1. /auth/kakao/callback 응답에서 신규 유저인 경우 User 정보를 함께 반환하도록 수정 -> 프론트에서 바로 활용 가능
2. SignupService에서 전달받은 SignupRequestDTO에 포함된 기본정보(accountId, name, email, birth, gender, provider)와 설문 응답을 함께 저장
3. provider가 없거나 null인 경우 기본값 'LOCAL'로 설정
4. provider가 'KAKAO'인 경우 더미 비밀번호 "kakao"로 처리하여 암호화 생략

### 테스트
신규 카카오 유저 : 로그인- > 설문 -> DB 확인 -> user테이블, user_info테이블 확인 -> 사용자 정보 및 설문 응답 저장 여부 확인

지저분한 주석은 월요일에 정리하겠습니다,,, 

<img width="577" height="109" alt="스크린샷 2025-07-31 234925" src="https://github.com/user-attachments/assets/4bffb616-64f2-4032-9a9e-45ecd12e1f43" />

<img width="2516" height="389" alt="스크린샷 2025-08-01 003424" src="https://github.com/user-attachments/assets/5899e374-8875-49f9-b014-da5785dc061b" />

<img width="2754" height="339" alt="스크린샷 2025-08-01 003450" src="https://github.com/user-attachments/assets/e7a7a102-11d8-4a36-8f96-492b81cba025" />




## 💬 리뷰 요구사항(선택 사항)
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
