### PR TITLE
♻️ findAccountIdByUuid 응답에 name 포함되도록 수정

### DIFF
--- a/src/main/java/org/finmate/member/controller/AccountRecoveryController.java
+++ b/src/main/java/org/finmate/member/controller/AccountRecoveryController.java
@@ -22,8 +22,7 @@ public class AccountRecoveryController {
     @PostMapping("/findaccountid")
     @ApiOperation(value = "아이디 찾기", notes = "이메일 인증이 완료된 UUID로 등록된 accountId를 반환")
     public FindAccountIdResponseDTO findAccountId(@RequestBody FindAccountIdRequestDTO dto) {
-        String accountId = accountRecoveryService.findAccountIdByUuid(dto.getUuid());
-        return new FindAccountIdResponseDTO(accountId);
+        return accountRecoveryService.findAccountIdByUuid(dto.getUuid());
     }
 
     @PostMapping("/changepassword/verify")

--- a/src/main/java/org/finmate/member/dto/FindAccountIdResponseDTO.java
+++ b/src/main/java/org/finmate/member/dto/FindAccountIdResponseDTO.java
@@ -7,5 +7,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FindAccountIdResponseDTO {
+    private String name;
     private String accountId;
 }

--- a/src/main/java/org/finmate/member/mapper/UserMapper.java
+++ b/src/main/java/org/finmate/member/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package org.finmate.member.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.finmate.member.domain.UserVO;
+import org.finmate.member.dto.FindAccountIdResponseDTO;
 
 @Mapper
 public interface UserMapper {
@@ -20,7 +21,7 @@ public interface UserMapper {
 
     boolean existsByAccountId(@Param("accountId") String accountId);
 
-    String findAccountIdByEmail(String email);
+    FindAccountIdResponseDTO findAccountIdByEmail(String email);
     boolean existsByAccountIdAndEmail(@Param("accountId") String accountId, @Param("email") String email);
     int updatePassword(@Param("accountId") String accountId, @Param("newPassword") String newPassword);
 }

--- a/src/main/java/org/finmate/member/service/AccountRecoveryService.java
+++ b/src/main/java/org/finmate/member/service/AccountRecoveryService.java
@@ -3,6 +3,7 @@ package org.finmate.member.service;
 import lombok.RequiredArgsConstructor;
 import org.finmate.member.domain.EmailAuthVO;
 import org.finmate.member.dto.ChangePasswordRequestDTO;
+import org.finmate.member.dto.FindAccountIdResponseDTO;
 import org.finmate.member.mapper.EmailAuthMapper;
 import org.finmate.member.mapper.UserMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,7 +17,7 @@ public class AccountRecoveryService {
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
 
-    public String findAccountIdByUuid(String uuid) {
+    public FindAccountIdResponseDTO findAccountIdByUuid(String uuid) {
         String email = emailAuthMapper.findEmailByVerifiedUuid(uuid);
         if (email == null) return null;
         return userMapper.findAccountIdByEmail(email);

--- a/src/main/resources/org/finmate/member/mapper/UserMapper.xml
+++ b/src/main/resources/org/finmate/member/mapper/UserMapper.xml
@@ -40,8 +40,8 @@
         SELECT COUNT(*) > 0 FROM user WHERE account_id = #{accountId}
     </select>
 
-    <select id="findAccountIdByEmail" resultType="String">
-        SELECT account_id FROM user WHERE email = #{email}
+    <select id="findAccountIdByEmail" resultType="org.finmate.member.dto.FindAccountIdResponseDTO">
+        SELECT name, account_id FROM user WHERE email = #{email}
     </select>
 
     <select id="existsByAccountIdAndEmail" resultType="boolean">


### PR DESCRIPTION
## 🔗 반영 브랜치
feature/login-signup -> develop

## 📝 작업 내용
프론트에서 아이디 찾기 결과 보여줄 때  회원 이름도 함께 보여주도록 name 추가했습니다.

## 💬 리뷰 요구사항(선택 사항)
