### PR TITLE
✨ 사용자 투자성향 기반 금융상품 추천 기능 머지 요청

### DIFF
--- a/src/main/java/org/finmate/member/dto/UserInfoDTO.java
+++ b/src/main/java/org/finmate/member/dto/UserInfoDTO.java
@@ -3,10 +3,12 @@ package org.finmate.member.dto;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 import org.finmate.member.domain.UserInfoVO;
+import org.finmate.member.domain.enums.Gender;
 import org.finmate.member.domain.enums.SpeedTag;
 import org.finmate.member.domain.enums.StrategyTag;
 import org.finmate.member.domain.enums.ValueTag;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -53,6 +55,39 @@ public class UserInfoDTO {
     @ApiModelProperty(value = "수정일")
     private LocalDateTime updatedAt;
 
+    @ApiModelProperty(value = "생년월일")
+    private LocalDate birth;
+
+    @ApiModelProperty(value = "성별 (MALE / FEMALE)")
+    private Gender gender;
+
+    @ApiModelProperty(value = "결혼 여부")
+    private Boolean isMarried;
+
+    @ApiModelProperty(value = "직업 유무")
+    private Boolean hasJob;
+
+    @ApiModelProperty(value = "대중교통 이용 여부")
+    private Boolean usesPublicTransport;
+
+    @ApiModelProperty(value = "운동 습관 여부")
+    private Boolean doesExercise;
+
+    @ApiModelProperty(value = "자주 여행을 다니는지 여부")
+    private Boolean travelsFrequently;
+
+    @ApiModelProperty(value = "자녀 유무")
+    private Boolean hasChildren;
+
+    @ApiModelProperty(value = "자가 주택 소유 여부")
+    private Boolean hasHouse;
+
+    @ApiModelProperty(value = "중소기업 재직 여부")
+    private Boolean employedAtSme;
+
+    @ApiModelProperty(value = "소액 대출 이용 여부")
+    private Boolean usesMicroloan;
+
 
     /**
      * VO -> DTO
@@ -72,6 +107,18 @@ public class UserInfoDTO {
                 .userLevel(vo.getUserLevel())
                 .characterTicket(vo.getCharacterTicket())
                 .updatedAt(vo.getUpdatedAt())
+
+                .gender(vo.getGender())
+                .isMarried(vo.getIsMarried())
+                .hasJob(vo.getHasJob())
+                .usesPublicTransport(vo.getUsesPublicTransport())
+                .doesExercise(vo.getDoesExercise())
+                .travelsFrequently(vo.getTravelsFrequently())
+                .hasChildren(vo.getHasChildren())
+                .hasHouse(vo.getHasHouse())
+                .employedAtSme(vo.getEmployedAtSme())
+                .usesMicroloan(vo.getUsesMicroloan())
+
                 .build();
     }
 
@@ -79,8 +126,7 @@ public class UserInfoDTO {
      * DTO -> VO
      */
     public UserInfoVO toVO(){
-        return UserInfoVO
-                .builder()
+        return UserInfoVO.builder()
                 .id(id)
                 .userId(userId)
                 .animalId(animalId)
@@ -94,6 +140,18 @@ public class UserInfoDTO {
                 .userLevel(userLevel)
                 .characterTicket(characterTicket)
                 .updatedAt(updatedAt)
+
+                .gender(gender)
+                .isMarried(isMarried)
+                .hasJob(hasJob)
+                .usesPublicTransport(usesPublicTransport)
+                .doesExercise(doesExercise)
+                .travelsFrequently(travelsFrequently)
+                .hasChildren(hasChildren)
+                .hasHouse(hasHouse)
+                .employedAtSme(employedAtSme)
+                .usesMicroloan(usesMicroloan)
+
                 .build();
     }
 }

--- a/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
+++ b/src/main/java/org/finmate/product/controller/ProductRecommendationController.java
@@ -6,12 +6,16 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.finmate.member.domain.CustomUser;
 import org.finmate.product.dto.ProductDTO;
 import org.finmate.product.mapper.ProductMapper;
+import org.finmate.product.service.ProductService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,7 +29,12 @@ public class ProductRecommendationController {
 
 
     private final ProductMapper productMapper;
+    private final ProductService productService;
 
+    /**
+     * 랜덤 상품 추천
+     * 메인페이지에서 비로그인 사용자에게 보여줄 8개의 랜덤한 상품
+     */
     @ApiOperation(value = "랜덤 상품 추천", notes = "메인 화면에서 무작위로 금융 상품 8개를 추천합니다.")
     @ApiResponses({
             @ApiResponse(code = 200, message = "정상적으로 랜덤 추천 상품을 반환했습니다."),
@@ -37,5 +46,23 @@ public class ProductRecommendationController {
                 .stream()
                 .map(ProductDTO::from)
                 .collect(Collectors.toList()));
+    }
+
+    /**
+     * 사용자 맞춤 상품 추천
+     * (사용자 성향 + 재무포트폴리오 + 회원가입설문 + 사용자 5대 지표)를 활용하여 상품 추천
+     */
+    @ApiOperation(value = "사용자 맞춤 상품 추천", notes = "사용자 성향에 맞는 상품을 추천합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "정상적으로 추천 상품을 반환했습니다."),
+            @ApiResponse(code = 500, message = "서버 오류 발생")
+    })
+    @GetMapping("/all")
+    ResponseEntity<List<ProductDTO<?>>> getCustomizedProductsRecommendation(@ApiIgnore @AuthenticationPrincipal CustomUser customUser){
+
+        // 사용자 ID 추출
+        Long userId = customUser.getUser().getId();
+
+        return ResponseEntity.ok(productService.getCustomizedProducts(userId));
     }
 }

--- a/src/main/java/org/finmate/product/service/ProductService.java
+++ b/src/main/java/org/finmate/product/service/ProductService.java
@@ -24,4 +24,7 @@ public interface ProductService {
     Long insertProductReview(ProductReviewDTO productReviewDTO, Long productId, Long userId);
 
     Long deleteProductReview(Long id, Long userId);
+
+    // 사용자 맞춤 추천 상품
+    List<ProductDTO<?>> getCustomizedProducts(Long userId);
 }

--- a/src/main/java/org/finmate/product/service/ProductServiceImpl.java
+++ b/src/main/java/org/finmate/product/service/ProductServiceImpl.java
@@ -9,11 +9,18 @@ import org.finmate.exception.NotFoundException;
 import org.finmate.member.domain.AnimalCharacterVO;
 import org.finmate.member.domain.CustomUser;
 import org.finmate.member.domain.UserInfoVO;
+import org.finmate.member.dto.UserInfoDTO;
 import org.finmate.member.mapper.AnimalCharacterMapper;
 import org.finmate.member.mapper.UserInfoMapper;
+import org.finmate.member.mapper.UserMapper;
+import org.finmate.portfolio.domain.InvestmentProfile;
 import org.finmate.portfolio.domain.PortfolioVO;
+import org.finmate.portfolio.dto.PortfolioDTO;
 import org.finmate.portfolio.mapper.PortfolioMapper;
+import org.finmate.product.domain.DepositVO;
+import org.finmate.product.domain.FundVO;
 import org.finmate.product.domain.ProductReviewVO;
+import org.finmate.product.domain.SavingsVO;
 import org.finmate.product.dto.ProductComparisonResultDTO;
 import org.finmate.product.dto.ProductDTO;
 import org.finmate.product.dto.ProductFilterDTO;
@@ -23,6 +30,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Log4j2
@@ -165,5 +175,174 @@ public class ProductServiceImpl implements ProductService {
                 filter.setQuery(null);
             }
         }
+    }
+
+    // 사용자 맞춤 추천 상품
+    @Override
+    public List<ProductDTO<?>> getCustomizedProducts(Long userId) {
+
+        // 사용자 재무포트폴리오 가져오기
+        PortfolioDTO portfolioDTO = PortfolioDTO.from(portfolioMapper.getPortfolio(userId));
+
+        // 사용자 인포
+        UserInfoDTO userInfoDTO = UserInfoDTO.from(userInfoMapper.getUserInfoById(userId));
+
+        // 모든 상품 조회
+        List<ProductDTO<?>> allProducts = productMapper.getAllProducts()
+                .stream()
+                .map(ProductDTO::from)
+                .collect(Collectors.toList());
+
+        // 거리가 짧은 순으로 정렬
+        return allProducts.stream()
+                .sorted(Comparator.comparingDouble(product -> getDistance(product, portfolioDTO, userInfoDTO)))
+//                .peek(product -> {
+//                    double distance = getDistance(product, portfolioDTO, userInfoDTO);
+//                    log.info("--------------------------------Product: {}, Distance: {}", product.getName(), distance);
+//                })
+                .collect(Collectors.toList());
+    }
+
+    // 거리 구하는 메소드
+    public static double getDistance(ProductDTO<?> productDTO, PortfolioDTO portfolioDTO, UserInfoDTO userInfoDTO){
+
+
+        /**
+         * 상품의 5대 지표 - 사용자의 5대 지표
+         */
+        Double adventureScore = productDTO.getAdventureScore() - userInfoDTO.getAdventureScore();
+        int valueTag = (productDTO.getValueTag().equals(userInfoDTO.getValueTag().name())) ? 1 : 0;
+        int speedTage = (productDTO.getSpeedTag().equals(userInfoDTO.getSpeedTag().name())) ? 1 : 0;
+        int strategyTag = (productDTO.getStrategyTag().equals(userInfoDTO.getStrategyTag().name())) ? 1 : 0;
+        Double minFinanceScore = productDTO.getMinFinanceScore() - userInfoDTO.getFinanceScore();
+
+        /**
+         * 회원 가입 설문
+         * 상품이 예적금이면 회원가입 필터 적용
+         */
+        int n = isRequirementViolated(productDTO, userInfoDTO);
+
+        /**
+         * 이상적인 재무 포트폴리오 - 사용자의 재무 포트폴리오
+         */
+        // 사용자의 이상적인 포트폴리오 비율
+        int[] standardPortfolio = getRatio(portfolioDTO.getInvestmentProfile());
+
+        // 사용자의 현재 재무 포트폴리오 비율
+        int currentCashRatio = (int) ((portfolioDTO.getCash() + portfolioDTO.getDeposit() + portfolioDTO.getSavings()) / portfolioDTO.getTotalAssets() * 100);
+        int currentBondRatio = (int) ((portfolioDTO.getBond() / portfolioDTO.getTotalAssets()) * 100);
+        int currentFundRatio = (int) ((portfolioDTO.getFund() + portfolioDTO.getStock()) / portfolioDTO.getTotalAssets() * 100);
+        int currentEtcRatio = (int) ((portfolioDTO.getOther() / portfolioDTO.getTotalAssets()) * 100);
+
+        // 이상적인 재무 포트폴리오 - 사용자의 재무 포트폴리오
+        int CashGap = currentCashRatio - standardPortfolio[0];
+        int BondGap = currentBondRatio - standardPortfolio[1];
+        int FundGap = currentFundRatio - standardPortfolio[2];
+        int EtcGap = currentEtcRatio - standardPortfolio[3];
+        int[] diff = new int[]{CashGap, BondGap, FundGap, EtcGap};
+
+        /**
+         * 사용자의 투자 성향 요약
+         */
+        String userProfileSummary = userInfoDTO.getProfileSummary();
+
+
+        /**
+         * 거리 계산 공식 사용
+         */
+
+        // 1. (이상 - 현재) 중에서 가장 작은 값 추출
+        int min = Integer.MAX_VALUE;
+        for (int i = 0; i < 4; i++) if (diff[i] < min) min = diff[i];
+
+
+        // 2. 모두 양수로 만들기 위해 offset 더함
+        int offset = -min + 1; // 최소값이 -30이면 +31
+        int[] positiveDiff = new int[4];
+        for (int i = 0; i < 4; i++) positiveDiff[i] = diff[i] + offset;
+
+
+        // 3. 반비례 가중치 = 1 / 값
+        double[] inverse = new double[4];
+        for (int i = 0; i < 4; i++) inverse[i] = 1.0 / positiveDiff[i];
+
+
+        // 4. 정규화
+        double sum = 0;
+        for (double v : inverse) sum += v;
+
+        double[] normalized = new double[4];
+        for (int i = 0; i < 4; i++) normalized[i] = inverse[i] / sum;
+
+
+        /**
+         * 상품 유형 별로 가중치 w4 추출
+         */
+        double w4 = 0.0;
+        if(productDTO.getDetail() instanceof SavingsVO) w4 =  normalized[0];
+        else if(productDTO.getDetail() instanceof DepositVO) w4 = normalized[0];
+        else if(productDTO.getDetail() instanceof FundVO) w4 = normalized[2];
+        else w4 = 0;
+
+        /**
+         * 거리 계산
+         * double
+         */
+        return (Math.sqrt(Math.pow(adventureScore, 2)
+                + Math.pow(valueTag, 2)
+                + Math.pow(speedTage, 2)
+                + Math.pow(strategyTag, 2)
+                + Math.pow(minFinanceScore, 2)
+                + 9999 * n) * w4);
+    }
+
+    // 회원 가입 설문 일치 여부 확인 메소드
+    private static int isRequirementViolated(ProductDTO<?> productDTO, UserInfoDTO userInfoDTO) {
+        if(productDTO.getDetail() instanceof SavingsVO userSavingsVO){
+            // 조건이 null 이 아닌 경우만 비교
+            if (userInfoDTO.getIsMarried() != null && !userSavingsVO.getIsMarried().equals(userInfoDTO.getIsMarried())) return 1;
+            if (userInfoDTO.getHasJob() != null && !userSavingsVO.getHasJob().equals(userInfoDTO.getHasJob())) return 1;
+            if (userInfoDTO.getUsesPublicTransport() != null && !userSavingsVO.getUsesPublicTransport().equals(userInfoDTO.getUsesPublicTransport())) return 1;
+            if (userInfoDTO.getDoesExercise() != null && !userSavingsVO.getDoesExercise().equals(userInfoDTO.getDoesExercise())) return 1;
+            if (userInfoDTO.getTravelsFrequently() != null && !userSavingsVO.getTravelsFrequently().equals(userInfoDTO.getTravelsFrequently())) return 1;
+            if (userInfoDTO.getHasChildren() != null && !userSavingsVO.getHasChildren().equals(userInfoDTO.getHasChildren())) return 1;
+            if (userInfoDTO.getHasHouse() != null && !userSavingsVO.getHasHouse().equals(userInfoDTO.getHasHouse())) return 1;
+            if (userInfoDTO.getEmployedAtSme() != null && !userSavingsVO.getEmployedAtSme().equals(userInfoDTO.getEmployedAtSme())) return 1;
+            if (userInfoDTO.getUsesMicroloan() != null && !userSavingsVO.getUsesMicroloan().equals(userInfoDTO.getUsesMicroloan())) return 1;
+            // gender는 ENUM이니까 equals로 비교
+            //if (userInfoDTO.getGender() != null && !userSavingsVO.getGender().equals(userInfoDTO.getGender())) return 1;
+
+            return 0;
+
+        }else if(productDTO.getDetail() instanceof DepositVO userDepositVO){
+            // 조건이 null 이 아닌 경우만 비교
+            if (userInfoDTO.getIsMarried() != null && !userDepositVO.equals(userInfoDTO.getIsMarried())) return 1;
+            if (userInfoDTO.getHasJob() != null && !userDepositVO.getHasJob().equals(userInfoDTO.getHasJob())) return 1;
+            if (userInfoDTO.getUsesPublicTransport() != null && !userDepositVO.getUsesPublicTransport().equals(userInfoDTO.getUsesPublicTransport())) return 1;
+            if (userInfoDTO.getDoesExercise() != null && !userDepositVO.getDoesExercise().equals(userInfoDTO.getDoesExercise())) return 1;
+            if (userInfoDTO.getTravelsFrequently() != null && !userDepositVO.getTravelsFrequently().equals(userInfoDTO.getTravelsFrequently())) return 1;
+            if (userInfoDTO.getHasChildren() != null && !userDepositVO.getHasChildren().equals(userInfoDTO.getHasChildren())) return 1;
+            if (userInfoDTO.getHasHouse() != null && !userDepositVO.getHasHouse().equals(userInfoDTO.getHasHouse())) return 1;
+            if (userInfoDTO.getEmployedAtSme() != null && !userDepositVO.getEmployedAtSme().equals(userInfoDTO.getEmployedAtSme())) return 1;
+            if (userInfoDTO.getUsesMicroloan() != null && !userDepositVO.getUsesMicroloan().equals(userInfoDTO.getUsesMicroloan())) return 1;
+            // gender는 ENUM이니까 equals로 비교
+            //if (userInfoDTO.getGender() != null && !userDepositVO.getGender().equals(userInfoDTO.getGender())) return 1;
+
+            return 0;
+        }else return 0;
+    }
+
+    // 이상적인 현금/예적금, 채권, 주식/펀드, 기타 비율 정의
+    public static final Map<InvestmentProfile, int[]> standardPortfolio = Map.of(
+            InvestmentProfile.CONSERVATIVE, new int[]{80, 20, 0, 0},  // 안전형
+            InvestmentProfile.CAUTIOUS,     new int[]{50, 30, 20, 0}, // 안정추구형
+            InvestmentProfile.BALANCED,     new int[]{20, 40, 40, 0}, // 위험중립형
+            InvestmentProfile.DYNAMIC,      new int[]{10, 20, 70, 0}, // 적극투자형
+            InvestmentProfile.AGGRESSIVE,   new int[]{0, 10, 80, 10}  // 공격투자형
+    );
+
+    // 성향별 이상적인 포트폴리오 비율 가져오는 메소드
+    public static int[] getRatio(InvestmentProfile profile) {
+        return standardPortfolio.get(profile);
     }
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
(#63 ) feature/recommendation -> develop

## 📝 작업 내용
<img width="710" height="409" alt="image" src="https://github.com/user-attachments/assets/5c41de24-63bb-4c29-a161-c98351f40c40" />
<br>
(예시 사용자 데이터)
<br>
1. 재무포트폴리오 성향: BALANCED<br>
2. 투자 성향 요약: 과감한<br>
3. 사용자 포트폴리오 재산(원): 500000.00, 2000000.00, 1500000.00, 2500000.00, 1000000.00, 2000000.00, 500000.00<br>
<br>

### 사용자 투자성향/포트폴리오 기반 금융상품 추천 로직 구현
- 사용자의 5대 성향(모험성향, 가치관, 투자속도, 전략성, 재정체력)과 이상적 포트폴리오 비율을 활용하여
각 상품과의 “거리”를 계산, 유사도가 높은 순으로 추천 리스트 생성
- 상품 유형(예적금/펀드 등)별로 포트폴리오 비중 차이를 반비례 가중치로 반영
- 회원가입 시 설문(필수조건) 불일치 상품은 추천에서 제외
- 관련 컨트롤러, 서비스, 매퍼 등 메소드 및 필드 추가/리팩토링

### 테스트 방법/확인 사항
- 서버 시작시 dummy/products/financial_products.json 에 있는 파일을 읽어서 더미 finance_products 생성
- user, userInfo, portfolio 더미 데이터 필요
- 사용자 토큰과 함께 POST 요청
- 거리값이 낮은(유사한) 상품이 추천 상위에 오는지 테스트

