### PR TITLE
🐛 회원 탈퇴 버그 수정

### DIFF
--- a/src/main/java/org/finmate/member/mapper/UserMapper.java
+++ b/src/main/java/org/finmate/member/mapper/UserMapper.java
@@ -3,7 +3,7 @@ package org.finmate.member.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.finmate.member.domain.UserVO;
-import org.finmate.member.dto.FindAccountIdResponseDTO;
+import org.finmate.member.dto.UserInfoDTO;
 
 import java.util.List;
 
@@ -19,9 +19,11 @@ public interface UserMapper {
 
     Long findUserIdByAccountId(String accountId);
 
+    UserInfoDTO findById(Long userId);
     void deleteUserInfoByUserId(Long userId);
     void deleteUserAttendanceByUserId(Long userId);
-    void deleteUserById(Long userId);
+    void deletePortfolioByUserId(Long userId);
+    int deleteUserById(Long userId);
 
     boolean existsByAccountId(@Param("accountId") String accountId);
 

--- a/src/main/resources/org/finmate/member/mapper/UserMapper.xml
+++ b/src/main/resources/org/finmate/member/mapper/UserMapper.xml
@@ -11,6 +11,11 @@
         INSERT INTO user (name, account_id, email, password, provider)
         VALUES (#{name}, #{accountId}, #{email}, #{password}, #{provider})
     </insert>
+
+    <select id="findById" parameterType="long" resultType="org.finmate.member.dto.UserInfoDTO">
+        SELECT * FROM user WHERE id = #{userId}
+    </select>
+
     <delete id="deleteByAccountId" parameterType="String">
         DELETE FROM user WHERE account_id = #{accountId}
     </delete>
@@ -30,6 +35,10 @@
 
     <delete id="deleteUserAttendanceByUserId">
         DELETE FROM user_attendance WHERE user_id = #{userId}
+    </delete>
+
+    <delete id="deletePortfolioByUserId">
+        DELETE FROM financial_portfolio WHERE user_id = #{userId}
     </delete>
 
     <delete id="deleteUserById">


### PR DESCRIPTION
## 🔗 반영 브랜치
feature/login-signup -> develop

## 📝 작업 내용
재무 포트폴리오 테이블이 userId를 참조하고 있어 외래키 제약조건 위반으로 회원 탈퇴 오류가 발생했습니다. userMapper에 포트폴리오 삭제하는 로직 추가해서 수정 했습니다.

## 💬 리뷰 요구사항(선택 사항)

