### PR TITLE
♻️ 상품 필터링 기능 수정 - 다중 선택 에러 해결, 상품 추천순 정렬 추가

### DIFF
--- a/src/main/java/org/finmate/product/controller/ProductController.java
+++ b/src/main/java/org/finmate/product/controller/ProductController.java
@@ -96,7 +96,7 @@ public class ProductController {
             @RequestParam(required = false) final String query,
 
             @ApiParam(value = "상품 타입", required = false, example = "DEPOSIT", allowableValues = "DEPOSIT,SAVINGS,FUND")
-            @RequestParam(required = false) final String productType,
+            @RequestParam(required = false) final List<String> productType,
 
             @ApiParam(value = "은행명 목록 (복수 선택 가능)", required = false, example = "국민")
             @RequestParam(required = false) final List<String> bankName,
@@ -105,7 +105,10 @@ public class ProductController {
             @RequestParam(required = false) final List<String> fundType,
 
             @ApiParam(value = "정렬 순서", required = false, example = "desc", allowableValues = "asc,desc")
-            @RequestParam(defaultValue = "desc") final String sortOrder) {
+            @RequestParam(defaultValue = "desc") final String sortType,
+
+            @ApiIgnore @AuthenticationPrincipal CustomUser user)
+    {
 
 
         // 필터 DTO 구성
@@ -114,10 +117,10 @@ public class ProductController {
         filter.setProductType(productType);
         filter.setBankName(bankName);
         filter.setFundType(fundType);
-        filter.setSortOrder(sortOrder);
+        filter.setSortType(sortType);
 
         // 필터링 서비스 호출
-        List<ProductDTO<?>> result = productService.getFilteredProducts(filter);
+        List<ProductDTO<?>> result = productService.getFilteredProducts(filter, user);
 
         if (result == null || result.isEmpty()) {
             throw new NotFoundException("조건에 맞는 상품을 찾을 수 없습니다.");

--- a/src/main/java/org/finmate/product/dto/ProductFilterDTO.java
+++ b/src/main/java/org/finmate/product/dto/ProductFilterDTO.java
@@ -19,7 +19,7 @@ public class ProductFilterDTO {
     private String query;
 
     @ApiModelProperty(value = "상품 타입", example = "DEPOSIT", allowableValues = "DEPOSIT,SAVINGS,FUND")
-    private String productType;
+    private List<String> productType;
 
     @ApiModelProperty(value = "은행명 목록", example = "국민은행")
     private List<String> bankName;
@@ -27,6 +27,7 @@ public class ProductFilterDTO {
     @ApiModelProperty(value = "펀드 종류 목록", example = "ETF")
     private List<String> fundType;
 
-    @ApiModelProperty(value = "정렬 순서", example = "desc", allowableValues = "asc,desc", notes = "desc: 수익률 높은순, asc: 수익률 낮은순")
-    private String sortOrder = "desc";
+    @ApiModelProperty(value = "정렬 방식", example = "YIELD_DESC",
+            allowableValues = "RECOMMENDED,YIELD_DESC,BASE_RATE_DESC")
+    private String sortType = "YIELD_DESC";
 }

--- a/src/main/java/org/finmate/product/service/ProductService.java
+++ b/src/main/java/org/finmate/product/service/ProductService.java
@@ -15,7 +15,7 @@ public interface ProductService {
   
     ProductComparisonResultDTO compareProducts(Long id1, Long id2, CustomUser user);
 
-    List<ProductDTO<?>> getFilteredProducts(ProductFilterDTO filter);
+    List<ProductDTO<?>> getFilteredProducts(ProductFilterDTO filter, CustomUser user);
 
     List<ProductReviewDTO> getProductReviews(Long id);
 

--- a/src/main/resources/org/finmate/product/mapper/ProductMapper.xml
+++ b/src/main/resources/org/finmate/product/mapper/ProductMapper.xml
@@ -416,8 +416,11 @@
         <include refid="productJoin"/>
         <where>
             <!-- 상품 타입 필터 (선택) - null이면 전체 조회 -->
-            <if test="productType != null and productType != ''">
-                AND p.product_type = #{productType}
+            <if test="productType != null and productType.size() > 0">
+                AND p.product_type IN
+                <foreach item="type" collection="productType" open="(" separator="," close=")">
+                    #{type}
+                </foreach>
             </if>
 
             <!-- 검색어 조건 (선택) -->
@@ -435,7 +438,7 @@
             </if>
 
             <!-- 펀드 종류 필터 (펀드일 때만) -->
-            <if test="productType == 'FUND' and fundType != null and fundType.size() > 0">
+            <if test="fundType != null and fundType.size() > 0">
                 AND f.fund_type IN
                 <foreach item="type" collection="fundType" open="(" separator="," close=")">
                     #{type}
@@ -444,18 +447,24 @@
         </where>
 
         <!-- 정렬: 수익률 기준만 -->
-        ORDER BY
-        (
-        CASE
-        WHEN p.product_type = 'FUND' THEN
-        p.expected_return
-        ELSE
-        p.expected_return + s.bonus_rate
-        END
-        )
         <choose>
-            <when test="sortOrder == 'asc'">ASC</when>
-            <otherwise>DESC</otherwise>
+            <when test="sortType != null and sortType.equals('BASE_RATE_DESC')">
+                ORDER BY p.expected_return DESC
+            </when>
+            <when test="sortType != null and sortType.equals('YIELD_DESC')">
+                ORDER BY
+                (
+                CASE
+                WHEN p.product_type = 'FUND' THEN
+                p.expected_return
+                ELSE
+                p.expected_return + COALESCE(s.bonus_rate, 0)
+                END
+                ) DESC
+            </when>
+            <otherwise>
+                ORDER BY p.id
+            </otherwise>
         </choose>
     </select>
     <select id="getProductReviewByProductId" resultType="ProductReviewVO">


### PR DESCRIPTION
## 🔗 반영 브랜치
(#117) feature/product-sort-refactoring -> develop

## 📝 작업 내용

상품 필터링이 다중 선택이 안 되는 문제가 있어서 수정하였습니다.

상품 조회에서 추천순 정렬 추가 및 수정하였습니다.
로그인 상태 - [추천순, 수익률 높, 기본금리 높] -> 기본값: 추천순
비로그인 상태 -  [수익률 높, 기본금리 높] -> 기본값: 수익률 높은순

## 💬 리뷰 요구사항(선택 사항)

