### PR TITLE
:recycle: 회원가입, 아이디찾기/비밀번호 변경 API 분리

### DIFF
--- a/src/main/java/org/finmate/email/controller/EmailAuthController.java
+++ b/src/main/java/org/finmate/email/controller/EmailAuthController.java
@@ -6,9 +6,11 @@ import org.finmate.email.dto.EmailAuthInitResponseDTO;
 import org.finmate.email.dto.EmailRequestDTO;
 import org.finmate.email.dto.EmailVerifyRequestDTO;
 import org.finmate.email.service.EmailAuthService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,18 +22,40 @@ public class EmailAuthController {
 
     @ApiOperation(value = "이메일 인증 요청", notes = "사용자의 이메일로 인증 코드를 전송합니다.")
     @ApiResponse(code = 200, message = "인증코드 발송 성공", response = EmailAuthInitResponseDTO.class)
-    @PostMapping( "/authentication")
+    @PostMapping("/authentication")
     public ResponseEntity<EmailAuthInitResponseDTO> sendAuthCode(
             @RequestBody final EmailRequestDTO request
     ) {
         String uuid = emailAuthService.sendAuthCode(request.getEmail());
         EmailAuthInitResponseDTO response = new EmailAuthInitResponseDTO(uuid);
-        return ResponseEntity.ok(response); //
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiOperation(
+            value = "회원가입용 이메일 인증 요청",
+            notes = "회원가입 시 이메일 중복 확인과 함께 인증 코드를 전송합니다. 이미 가입된 이메일인 경우 오류를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "인증코드 발송 성공", response = EmailAuthInitResponseDTO.class),
+            @ApiResponse(code = 400, message = "이미 가입된 이메일", response = Map.class)
+    })
+    @PostMapping("/authentication/signup")
+    public ResponseEntity<?> sendAuthCodeForSignUp(
+            @RequestBody final EmailRequestDTO request
+    ) {
+        try {
+            String uuid = emailAuthService.sendAuthCodeForSignUp(request.getEmail());
+            EmailAuthInitResponseDTO response = new EmailAuthInitResponseDTO(uuid);
+            return ResponseEntity.ok(response);
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", e.getMessage()));
+        }
     }
 
     @ApiOperation(value = "이메일 인증 코드 검증", notes = "UUID와 인증 코드를 통해 이메일 인증을 검증합니다.")
     @ApiResponse(code = 200, message = "인증 성공 여부 반환", response = Boolean.class)
-    @PostMapping( "/authentication/verify")
+    @PostMapping("/authentication/verify")
     public ResponseEntity<Boolean> verifyAuthCode(
             @RequestBody final EmailVerifyRequestDTO request
     ) {

--- a/src/main/java/org/finmate/email/service/EmailAuthService.java
+++ b/src/main/java/org/finmate/email/service/EmailAuthService.java
@@ -1,6 +1,7 @@
 package org.finmate.email.service;
 
 public interface EmailAuthService {
+    String sendAuthCodeForSignUp(String email);
     String sendAuthCode(String email);
     boolean verifyCode(String uuid, String inputCode);
 }

--- a/src/main/java/org/finmate/member/mapper/UserMapper.java
+++ b/src/main/java/org/finmate/member/mapper/UserMapper.java
@@ -27,6 +27,7 @@ public interface UserMapper {
     int deleteUserById(Long userId);
 
     boolean existsByAccountId(@Param("accountId") String accountId);
+    boolean existsByEmail(@Param("email") String email);
 
     UserVO findAccountIdByEmail(String email);
     boolean existsByAccountIdAndEmail(@Param("accountId") String accountId, @Param("email") String email);

--- a/src/main/resources/org/finmate/member/mapper/UserMapper.xml
+++ b/src/main/resources/org/finmate/member/mapper/UserMapper.xml
@@ -65,6 +65,11 @@
         SELECT id FROM user;
     </select>
 
+    <select id="existsByEmail" resultType="boolean">
+        SELECT COUNT(*) > 0 FROM user
+        WHERE email = #{email}
+    </select>
+
     <update id="updatePassword">
         UPDATE user
         SET password = #{newPassword}


### PR DESCRIPTION
## 🔗 반영 브랜치
refactor/email-authentication -> develop

## 📝 작업 내용
회원가입에서 사용할 중복확인 하는 이메일 인증과
아이디 찾기/비밀번호 변경에서 사용할 가입된 이메일인지 확인하는 이메일 인증 API로 분리했습니다.

## 💬 리뷰 요구사항(선택 사항)
