### PR TITLE
♻️ API 문서 수정

### DIFF
--- a/src/main/java/org/finmate/attendance/dto/UserAttendanceDTO.java
+++ b/src/main/java/org/finmate/attendance/dto/UserAttendanceDTO.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@ApiModel(value = "사용자 출석 정보 DTO", description = "현재 유저의 출석 체크 정보입니다.")
+@ApiModel(description = "현재 사용자의 출석 체크에 관련된 DTO입니다.")
 public class UserAttendanceDTO {
     @ApiModelProperty(value = "첫 로그인인지 확인(출석을 했는지 안했는지 확인)")
     private Boolean rewardClaimed;

--- a/src/main/java/org/finmate/common/controller/HealthController.java
+++ b/src/main/java/org/finmate/common/controller/HealthController.java
@@ -1,7 +1,11 @@
 package org.finmate.common.controller;
 
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.finmate.quiz.dto.QuizDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,18 +18,23 @@ import java.sql.SQLException;
 
 @RestController
 @RequiredArgsConstructor
+@Api(tags = "헬스체크 API")
 public class HealthController {
 
     private final DataSource dataSource;
 
     // 준비/의존성까지 확인 (DB)
     @GetMapping("/healthz")
+    @ApiOperation(value = "데이터베이스 포함 헬스 체크", notes = "데이터 베이스 연결 및 동작 확인 후 HttpStatus 200 반환")
+    @ApiResponse(code = 200, message = "성공적으로 요청이 처리되었습니다.", response = String.class)
     public ResponseEntity<String> readiness() {
         return checkDb() ? ResponseEntity.ok("ok")
                 : ResponseEntity.status(503).body("db error");
     }
 
     @GetMapping("/healthz/liveness")
+    @ApiOperation(value = "단순 헬스체크", notes = "서버 상태를 확인하는 API 단순 HttpStatus 200 반환")
+    @ApiResponse(code = 200, message = "성공적으로 요청이 처리되었습니다.", response = String.class)
     public String liveness() { return "ok"; }
 
     private boolean checkDb() {

--- a/src/main/java/org/finmate/member/controller/LevelController.java
+++ b/src/main/java/org/finmate/member/controller/LevelController.java
@@ -1,12 +1,16 @@
 package org.finmate.member.controller;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.finmate.member.domain.CustomUser;
 import org.finmate.member.dto.LevelRequestDTO;
 import org.finmate.member.dto.LevelResponseDTO;
 import org.finmate.member.mapper.UserInfoMapper;
 import org.finmate.member.service.LevelService;
+import org.finmate.security.dto.AuthResultDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +28,8 @@ public class LevelController {
      * 사용자 레벨 조회
      */
     @GetMapping
+    @ApiOperation(value = "사용자 레벨 조회", notes = "사용자 주입을 통해 현재 사용자 레벨 반환")
+    @ApiResponse(code = 200, message = "정상적으로 요청이 처리되었습니다.", response = LevelResponseDTO.class)
     public ResponseEntity<LevelResponseDTO> getLevel(@ApiIgnore @AuthenticationPrincipal CustomUser customUser){
 
         Long userId = customUser.getUser().getId();
@@ -34,6 +40,8 @@ public class LevelController {
      * 사용자 경험치에 따른 레벨 증가 및 캐릭터 변경권 반환
      */
     @PostMapping
+    @ApiOperation(value = "사용자 레벨 증가 요청", notes = "사용자 경험치에 따른 레벨 증가 및 캐릭터 변경권 반환")
+    @ApiResponse(code = 200, message = "정상적으로 요청이 처리되었습니다.", response = LevelResponseDTO.class)
     public ResponseEntity<LevelResponseDTO> processLevelUp(@ApiIgnore @AuthenticationPrincipal CustomUser customUser, @RequestBody LevelRequestDTO dto){
 
         Long userId = customUser.getUser().getId();

--- a/src/main/java/org/finmate/member/dto/SignupRequestDTO.java
+++ b/src/main/java/org/finmate/member/dto/SignupRequestDTO.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(value = "회원가입 요청", description = "회원가입 시 필요한 사용자 정보 DTO")
+@ApiModel(description = "회원가입 시 필요한 사용자 정보 DTO")
 public class SignupRequestDTO {
 
     @ApiModelProperty(value = "가입 방식", example = "LOCAL 또는 KAKAO")

--- a/src/main/java/org/finmate/mypage/dto/UserStatResponseDTO.java
+++ b/src/main/java/org/finmate/mypage/dto/UserStatResponseDTO.java
@@ -14,7 +14,7 @@ import org.finmate.member.domain.enums.ValueTag;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ApiModel(value = "사용자 스탯 요청", description = "등록된 사용자 스탯 정보 DTO")
+@ApiModel(description = "등록된 사용자 스탯 정보 DTO")
 public class UserStatResponseDTO {
     @ApiModelProperty(value = "모험 성향(위험 감수도)", example = "0")
     private Double adventureScore;

--- a/src/main/java/org/finmate/quiz/controller/QuizController.java
+++ b/src/main/java/org/finmate/quiz/controller/QuizController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @Log4j2
 @Slf4j
 @RequestMapping("/api/quiz")
-@Api(tags = "Quiz API 컨트롤러")
+@Api(tags = "퀴즈 API")
 public class QuizController {
 
     private final QuizService quizService;

--- a/src/main/java/org/finmate/quiz/controller/QuizSolvedController.java
+++ b/src/main/java/org/finmate/quiz/controller/QuizSolvedController.java
@@ -1,6 +1,7 @@
 package org.finmate.quiz.controller;
 
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -19,6 +20,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @RequiredArgsConstructor
 @Log4j2
 @RequestMapping("/api/quizsolved")
+@Api(tags = "퀴즈 풀이 여부 확인 API")
 public class QuizSolvedController {
 
     private final QuizService quizService;

--- a/src/main/java/org/finmate/quiz/dto/QuizSolvedDTO.java
+++ b/src/main/java/org/finmate/quiz/dto/QuizSolvedDTO.java
@@ -9,7 +9,7 @@ import org.finmate.attendance.domain.UserAttendanceVO;
 @AllArgsConstructor
 @Builder
 @Data
-@ApiModel(value ="퀴즈 풀이 체크 DTO", description = "유저의 퀴즈 풀이 여부 DTO")
+@ApiModel(description = "유저의 퀴즈 풀이 여부 DTO")
 public class QuizSolvedDTO {
     @ApiModelProperty(value = "유저가 오늘 퀴즈를 풀었는지 확인")
     private Boolean quizSolved;


### PR DESCRIPTION
## 🔗 반영 브랜치
(#100 ) `refactor/fix-swagger-ui`-> `develop`

## 📝 작업 내용
- DTO의 value를 전부 삭제하였습니다.
- 클래스 이름 그대로 노출하는 게 보통 직관적이라서 굳이 적지 않음. (오히려 value를 따로 주면 Swagger 문서의 이름과 실제 코드 클래스명이 달라져서, 보는 사람이 혼란스러울 수 있음)
- API 태그가 달리지 않은 엔드포인트에 추가적으로 문서화를 진행했습니다. (HealthController, QuizSolvedController)
